### PR TITLE
Add vscode-dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Theme | Preview
 [`nord`](colors/nord.lua?raw=1) | ![nord_preview](https://user-images.githubusercontent.com/22625346/92419103-6baab180-f139-11ea-8638-d90db10da086.png)
 [`winter`](colors/winter.lua?raw=1) | ![winter_preview](https://user-images.githubusercontent.com/3920290/80304194-5c3f5300-87ac-11ea-9acf-33892579093e.png)
 [`zenburn`](colors/zenburn.lua?raw=1) | ![zenburn_preview](https://i.imgur.com/XUIJwMs.png)
+[`vscode-dark`](colors/vscode-dark.lua?raw=1) | ![vscode-dark_preview](https://i.imgur.com/GcSGaZc.png)
 
 ## Light
 

--- a/colors/vscode-dark.lua
+++ b/colors/vscode-dark.lua
@@ -1,3 +1,6 @@
+-- Most of the colors are taken from:
+-- https://github.com/microsoft/vscode/tree/master/extensions/theme-defaults/themes
+
 local style = require "core.style"
 local common = require "core.common"
 
@@ -26,3 +29,9 @@ style.syntax["literal"] = { common.color "#569CD6" }
 style.syntax["string"] = { common.color "#CE9178" }
 style.syntax["operator"] = { common.color "#D4D4D4" } -- = + - / < >
 style.syntax["function"] = { common.color "#DCDCAA" }
+
+-- PLUGINS
+style.linter_warning = { common.color "#B89500" }     -- linter
+style.bracketmatch_color = { common.color "#76BCFF" } -- bracketmatch
+style.guide = { common.color "#404040" }              -- indentguide
+style.guide_width = 1                                 -- indentguide

--- a/colors/vscode-dark.lua
+++ b/colors/vscode-dark.lua
@@ -1,0 +1,28 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#1E1E1E" }
+style.background2 = { common.color "#252526" }
+style.background3 = { common.color "#252526" }
+style.text = { common.color "#D4D4D4" }
+style.caret = { common.color "#FFFFFF" }
+style.accent = { common.color "#76BCFF" } -- Text in autocomplete and command, col(>80) in satusbar
+style.dim = { common.color "#7A7A7A" } -- Text of nonactive tabs, prefix in log
+style.divider = { common.color "#1E1E1E" }
+style.selection = { common.color "#264F78" }
+style.line_number = { common.color "#707070" }
+style.line_number2 = { common.color "#A0A0A0" } -- Number on line with caret
+style.line_highlight = { common.color "#333A40"}
+style.scrollbar = { common.color "#404040" }
+style.scrollbar2 = { common.color "#707070" } -- Hovered
+
+style.syntax["normal"] = { common.color "#D4D4D4" }
+style.syntax["symbol"] = { common.color "#D4D4D4" }
+style.syntax["comment"] = { common.color "#6A9955" }
+style.syntax["keyword"] = { common.color "#569CD6" }  -- local function end, if case
+style.syntax["keyword2"] = { common.color "#C586C0" } -- self, int float
+style.syntax["number"] = { common.color "#B5CEA8" }
+style.syntax["literal"] = { common.color "#569CD6" }
+style.syntax["string"] = { common.color "#CE9178" }
+style.syntax["operator"] = { common.color "#D4D4D4" } -- = + - / < >
+style.syntax["function"] = { common.color "#DCDCAA" }

--- a/colors/vscode-dark.lua
+++ b/colors/vscode-dark.lua
@@ -27,7 +27,7 @@ style.syntax["keyword2"] = { common.color "#C586C0" } -- self, int float
 style.syntax["number"] = { common.color "#B5CEA8" }
 style.syntax["literal"] = { common.color "#569CD6" }
 style.syntax["string"] = { common.color "#CE9178" }
-style.syntax["operator"] = { common.color "#D4D4D4" } -- = + - / < >
+style.syntax["operator"] = { common.color "#8590A5"}  -- = + - / < >
 style.syntax["function"] = { common.color "#DCDCAA" }
 
 -- PLUGINS


### PR DESCRIPTION
Based on dark and dark+ default themes from vs code.
Compare my version with dark+:
![image](https://user-images.githubusercontent.com/25588359/98279850-68457200-1f92-11eb-9772-cdaa35605592.png)
Unfortunately, cannot make separators between inactive tabs.