### PR TITLE
Added my own set of color themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ embedded in the table.*
 
 Theme | Preview
 ------|-----------------------------------------
+[`ayu-mirage`](colors/ayu-mirage.lua?raw=1) | ![ayu-mirage_preview](https://user-images.githubusercontent.com/16415678/119024935-e9e77500-b9a3-11eb-874b-a139e8e5515d.png)
 [`dracula`](colors/dracula.lua?raw=1) | ![dracula_preview](https://user-images.githubusercontent.com/3920290/81507632-9ead7780-92f6-11ea-85e9-7cfb9ffa97ae.png)
 [`duorand`](colors/duorand.lua?raw=1) |
 [`duotone`](colors/duotone.lua?raw=1) | ![duotone_preview](https://i.imgur.com/ZND82Lv.png)
@@ -27,7 +28,10 @@ Theme | Preview
 
 Theme | Preview
 ------|-----------------------------------------
+[`ayu-light`](colors/ayu-light.lua?raw=1) | ![ayu-light_preview](https://user-images.githubusercontent.com/16415678/119024733-b3115f00-b9a3-11eb-91ae-b9d4f1d34a6a.png)
 [`github`](colors/github.lua?raw=1) | ![github_preview](https://user-images.githubusercontent.com/3920290/80308013-800e9300-87c4-11ea-88a7-1f56104a7423.png)
 [`moe`](colors/moe.lua?raw=1) | ![moe_preview](https://i.imgur.com/IGEtafP.png)
+[`nice`](colors/nice.lua?raw=1) | ![nice_preview](https://user-images.githubusercontent.com/16415678/119025111-18655000-b9a4-11eb-82f5-9ccf483152a1.png)
+[`noctis-lilac`](colors/noctis-lilac.lua?raw=1) | ![noctis-lilac_preview](https://user-images.githubusercontent.com/16415678/119025572-8f024d80-b9a4-11eb-99b6-5bc222053b5f.png)
 [`solarized_light`](colors/solarized_light.lua?raw=1) | ![solarized_light_preview](https://user-images.githubusercontent.com/3920290/81503910-233fcc00-92de-11ea-9d6d-0a32212e6f02.png)
 [`solarobj`](colors/solarobj.lua?raw=1) | ![solarobj_preview](https://i.imgur.com/3EHFlx2.png)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ embedded in the table.*
 
 Theme | Preview
 ------|-----------------------------------------
+[`anoldhope`](colors/anoldhope.lua?raw=1) | ![anoldhope_preview](https://user-images.githubusercontent.com/16415678/119025918-e4d6f580-b9a4-11eb-8ca0-58b7b7f48dbf.png)
 [`ayu-mirage`](colors/ayu-mirage.lua?raw=1) | ![ayu-mirage_preview](https://user-images.githubusercontent.com/16415678/119024935-e9e77500-b9a3-11eb-874b-a139e8e5515d.png)
 [`dracula`](colors/dracula.lua?raw=1) | ![dracula_preview](https://user-images.githubusercontent.com/3920290/81507632-9ead7780-92f6-11ea-85e9-7cfb9ffa97ae.png)
 [`duorand`](colors/duorand.lua?raw=1) |

--- a/colors/anoldhope.lua
+++ b/colors/anoldhope.lua
@@ -1,0 +1,53 @@
+local style = require "core.style"
+local common = require "core.common"
+
+local palette = {
+  very_light_gray  = { common.color "#cbcdd2" },
+  light_gray       = { common.color "#848794" },
+  gray             = { common.color "#686b78" },
+  dark_gray        = { common.color "#45474f" },
+  almost_dark_gray = { common.color "#2e2f33" },
+  very_dark_gray   = { common.color "#1c1d21" },
+  ui               = { common.color "#151619" },
+  ui_dark          = { common.color "#111214" },
+
+  vader    = { common.color "#eb3d54" },
+  luke     = { common.color "#ef7c2a" },
+  threepio = { common.color "#e5cd52" },
+  yoda     = { common.color "#78bd65" },
+  artoo    = { common.color "#4fb4d8" },
+}
+
+style.background = palette.very_dark_gray
+style.background2 = palette.ui
+style.background3 = palette.ui
+style.text = palette.very_light_gray
+style.caret = palette.artoo
+style.accent = palette.artoo
+style.dim = palette.gray
+style.divider = palette.ui_dark
+style.selection = palette.dark_gray
+style.line_number = palette.dark_gray
+style.line_number2 = palette.light_gray
+style.line_highlight = palette.almost_dark_gray
+style.scrollbar = palette.dark_gray
+style.scrollbar2 = palette.light_gray
+
+style.syntax["normal"] = palette.very_light_gray
+style.syntax["symbol"] = palette.very_light_gray
+style.syntax["comment"] = palette.light_gray
+style.syntax["keyword"] = palette.yoda
+style.syntax["keyword2"] = palette.luke
+style.syntax["number"] = palette.luke
+style.syntax["literal"] = palette.luke
+style.syntax["string"] = palette.artoo
+style.syntax["operator"] = palette.vader
+style.syntax["function"] = palette.threepio
+
+-- lint+ support
+style.lint = {
+  info = palette.artoo,
+  hint = palette.threepio,
+  warning = palette.threepio,
+  error = palette.vader,
+}

--- a/colors/ayu-light.lua
+++ b/colors/ayu-light.lua
@@ -1,0 +1,36 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#FAFAFA" }
+style.background2 = { common.color "#FAFAFA" }
+style.background3 = { common.color "#FAFAFA" }
+style.text = { common.color "#575F66" }
+style.caret = { common.color "#FF9400" }
+style.accent = { common.color "#FF9400" }
+style.dim = { common.color "#8A9199" }
+style.divider = { common.color "#F0F0F0" }
+style.selection = { common.color "#E7E8E9" }
+style.line_number = { 138, 145, 153, 102 }
+style.line_number2 = { 138, 145, 153, 204 }
+style.line_highlight = { 138, 145, 153, 26 }
+style.scrollbar = { 138, 145, 153, 46 }
+style.scrollbar2 = { 138, 145, 153, 89 }
+
+style.syntax["normal"] = { common.color "#575F66" }
+style.syntax["symbol"] = { common.color "#575F66" }
+style.syntax["comment"] = { common.color "#ABB0B6" }
+style.syntax["keyword"] = { common.color "#FA8D3E" }
+style.syntax["keyword2"] = { common.color "#399EE6" }
+style.syntax["number"] = { common.color "#A37ACC" }
+style.syntax["literal"] = { common.color "#A37ACC" }
+style.syntax["string"] = { common.color "#86B300" }
+style.syntax["operator"] = { common.color "#ED9366" }
+style.syntax["function"] = { common.color "#F2AE49" }
+
+-- lint+ support
+style.lint = {
+  info = style.syntax["keyword2"],
+  hint = style.syntax["function"],
+  warning = style.syntax["function"],
+  error = { common.color "#F51818" }
+}

--- a/colors/ayu-mirage.lua
+++ b/colors/ayu-mirage.lua
@@ -1,0 +1,36 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#1F2430" }
+style.background2 = { common.color "#232834" }
+style.background3 = { common.color "#232834" }
+style.text = { common.color "#CBCCC6" }
+style.caret = { common.color "#FFCC66" }
+style.accent = { common.color "#FFCC66" }
+style.dim = { common.color "#707A8C" }
+style.divider = { common.color "#191E2A" }
+style.selection = { common.color "#343a4c" }
+style.line_number = { common.color "#404755" }
+style.line_number2 = { common.color "#5f687a" }
+style.line_highlight = { common.color "#191E2A" }
+style.scrollbar = { common.color "#707A8C" }
+style.scrollbar2 = { common.color "#707A8C" }
+
+style.syntax["normal"] = { common.color "#CBCCC6" }
+style.syntax["symbol"] = { common.color "#CBCCC6" }
+style.syntax["comment"] = { common.color "#5C6773" }
+style.syntax["keyword"] = { common.color "#FFA759" }
+style.syntax["keyword2"] = { common.color "#73D0FF" }
+style.syntax["number"] = { common.color "#D4BFFF" }
+style.syntax["literal"] = { common.color "#D4BFFF" }
+style.syntax["string"] = { common.color "#BAE67E" }
+style.syntax["operator"] = { common.color "#F29E74" }
+style.syntax["function"] = { common.color "#FFD580" }
+
+-- lint+ support
+style.lint = {
+  info = style.syntax["keyword2"],
+  hint = style.syntax["function"],
+  warning = style.syntax["function"],
+  error = { common.color "#FF3333" }
+}

--- a/colors/nice.lua
+++ b/colors/nice.lua
@@ -1,0 +1,28 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#f2f2f2" }
+style.background2 = { common.color "#e4e4e4" }
+style.background3 = { common.color "#e4e4e4" }
+style.text = { common.color "#404040" }
+style.caret = { common.color "#181818" }
+style.accent = { common.color "#181818" }
+style.dim = { common.color "#b0b0b0" }
+style.divider = { common.color "#e4e4e4" }
+style.selection = { common.color "#e4e4e4" }
+style.line_number = { common.color "#d0d0d0" }
+style.line_number2 = { common.color "#808080" }
+style.line_highlight = { common.color "#f2f2f2" }
+style.scrollbar = { common.color "#e0e0e0" }
+style.scrollbar2 = { common.color "#c0c0c0" }
+
+style.syntax["normal"] = { common.color "#181818" }
+style.syntax["symbol"] = { common.color "#181818" }
+style.syntax["comment"] = { common.color "#787878" }
+style.syntax["keyword"] = { common.color "#c53fe0" }
+style.syntax["keyword2"] = { common.color "#ba6900" }
+style.syntax["number"] = { common.color "#ba6900" }
+style.syntax["literal"] = { common.color "#ba6900" }
+style.syntax["string"] = { common.color "#459523" }
+style.syntax["operator"] = { common.color "#181818" }
+style.syntax["function"] = { common.color "#2f72d6" }

--- a/colors/noctis-lilac.lua
+++ b/colors/noctis-lilac.lua
@@ -1,0 +1,36 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#f2f1f8" }
+style.background2 = { common.color "#eae9f7" }
+style.background3 = { common.color "#d2cef3" }
+style.text = { common.color "#7060eb" }
+style.caret = { common.color "#5c49e9" }
+style.accent = { common.color "#00c6e0" }
+style.dim = { common.color "#757191" }
+style.divider = { common.color "#b5adeb" }
+style.selection = { common.color "#d6d1f3" }
+style.line_number = { common.color "#9d9ab1" }
+style.line_number2 = { common.color "#7060eb" }
+style.line_highlight = { common.color "#e0def2" }
+style.scrollbar = { common.color "#c1ced5" }
+style.scrollbar2 = { common.color "#d2cef3" }
+
+style.syntax["normal"] = { common.color "#0c006b" }
+style.syntax["symbol"] = { common.color "#f49725" }
+style.syntax["comment"] = { common.color "#9995b7" }
+style.syntax["keyword"] = { common.color "#e6412d" }
+style.syntax["keyword2"] = { common.color "#0094f0" }
+style.syntax["number"] = { common.color "#5842ff" }
+style.syntax["literal"] = { common.color "#5842ff" }
+style.syntax["string"] = { common.color "#00b368" }
+style.syntax["operator"] = { common.color "#ff5792" }
+style.syntax["function"] = { common.color "#0095a8" }
+
+-- lint+ support
+style.lint = {
+  info = style.syntax["keyword2"],
+  hint = style.syntax["string"],
+  warning = style.syntax["symbol"],
+  error = style.syntax["keyword"],
+}


### PR DESCRIPTION
This PR includes a bunch of color themes I ported over (or created for) lite over my few months of using it. Some of the themes contain extra colors for [lint+](https://github.com/liquidev/lintplus) support, hopefully that's not a problem.

Themes included:
- [Ayu Mirage and Ayu Light](https://github.com/ayu-theme/ayu-colors)
- [An Old Hope](https://github.com/jesseleite/an-old-hope-syntax-atom/) from Atom
- `nice`, a light theme based on the default light theme of mdBook (which is in turn based on Atelier Dune)
- [Noctis Lilac](https://github.com/liviuschera/noctis) from VS Code